### PR TITLE
Enforce ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ class CSSLoader {
   fetch( load, fetch ) {
     let path = load.metadata.pluginArgument,
       deps = this._deps[path] = []
-    console.log( `Fetch: ${path}` )
     // Create the element for this file if it isn't already
     // to ensure the correct order of output
     let elem = this.getElement( path )
@@ -48,7 +47,7 @@ class CSSLoader {
 // has a preferable debugging experience. Falls back to a simple <style>
 // tag if not.
   inject( source, elem ) {
-    if ( BUILD_MODE) {
+    if ( BUILD_MODE ) {
       elem.source = source
     } else if ( USE_STYLE_TAGS ) {
       elem.innerHTML = source
@@ -63,8 +62,6 @@ class CSSLoader {
   }
 
   getElement( path, beforeElem ) {
-    console.log(path)
-    console.log(this._cache)
     if ( !BUILD_MODE ) {
       let id = `jspm-css-loader-${path}`
       return document.getElementById( id ) || this.createElement( id, beforeElem )
@@ -78,7 +75,6 @@ class CSSLoader {
     let head = document.getElementsByTagName( 'head' )[0],
       cssElement = document.getElementById( id )
     if ( cssElement ) console.warn( "WHAT!!" )
-    console.log( `Create: ${id}` )
 
     if ( USE_STYLE_TAGS ) {
       cssElement = document.createElement( 'style' )
@@ -113,7 +109,6 @@ class CSSLoader {
     // This ensures elements are created in the right order:
     // dependencies before parents, siblings in source-order
     let elem = this.getElement( canonicalPath, canonicalParent )
-    console.log( `Imports: ${relativeTo} -> ${canonicalPath}` )
 
     return System.import( `./${canonicalPath}!${this.moduleName}` ).then( exportedTokens => {
       // If we're in BUILD_MODE, the tokens aren't actually returned,
@@ -122,9 +117,12 @@ class CSSLoader {
     } )
   }
 
-  bundle( loads, opts ) {
-    console.log(this._cache)
-    let css = this._cache.map( c => c.source ).join( "\n" )
+  bundle() {
+    return `(function(c){var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})("${this.getAllSources()}");`
+  }
+
+  getAllSources() {
+    return this._cache.map( c => c.source ).join( "\n" )
       .replace( /(["\\])/g, '\\$1' )
       .replace( /[\f]/g, "\\f" )
       .replace( /[\b]/g, "\\b" )
@@ -132,8 +130,7 @@ class CSSLoader {
       .replace( /[\t]/g, "\\t" )
       .replace( /[\r]/g, "\\r" )
       .replace( /[\u2028]/g, "\\u2028" )
-      .replace( /[\u2029]/g, "\\u2029" );
-    return `(function(c){var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})("${css}");`
+      .replace( /[\u2029]/g, "\\u2029" )
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 import Core from 'css-modules-loader-core'
 import path from 'path'
 import autoprefixer from './autoprefixer'
-let _source = []
 
 const BUILD_MODE = typeof window === 'undefined'
-const USE_STYLE_TAGS = BUILD_MODE || !window.Blob || !window.URL || !URL.createObjectURL || navigator.userAgent.match( /phantomjs/i )
+const USE_STYLE_TAGS = true || BUILD_MODE || !window.Blob || !window.URL || !URL.createObjectURL || navigator.userAgent.match( /phantomjs/i )
 
 class CSSLoader {
   constructor( plugins, moduleName ) {
@@ -12,27 +11,29 @@ class CSSLoader {
     this.bundle = this.bundle.bind( this )
     this.moduleName = moduleName || __moduleName
     this.core = new Core( plugins )
-    this._cache = { _source }
+    this._cache = []
     this._deps = {}
   }
 
   fetch( load, fetch ) {
     let path = load.metadata.pluginArgument,
-      deps = this._deps[path] = [],
-      elem = this.getElement( path )
+      deps = this._deps[path] = []
     console.log( `Fetch: ${path}` )
+    // Create the element for this file if it isn't already
+    // to ensure the correct order of output
+    let elem = this.getElement( path )
     // Use the default Load to fetch the source
     return fetch( load ).then( source => {
       // Pass this to the CSS Modules core to be translated
       // triggerImport is how dependencies are resolved
+      // we don't use the trace argument because we can use the dom
       return this.core.load( source, path, "", this.triggerImport.bind( this ) )
     } ).then( ( { injectableSource, exportTokens } ) => {
+      this.inject( injectableSource, elem )
       if ( BUILD_MODE ) {
-        this._cache[path] = exportTokens
-        _source.push( injectableSource ) //TODO: ordering!
+        elem.tokens = exportTokens
         return `export default ${JSON.stringify( exportTokens )}`
       } else {
-        this.inject( injectableSource, elem )
         // And return out exported variables.
         let imports = deps.map( d => `import "${d}"` ).join( ";" ),
         // on a reload, the only thing we need to do is cause a repaint
@@ -46,24 +47,30 @@ class CSSLoader {
 // Uses a <link> with a Blob URL if that API is available, since that
 // has a preferable debugging experience. Falls back to a simple <style>
 // tag if not.
-  inject( source, cssElement ) {
-    if ( USE_STYLE_TAGS ) {
-      cssElement.innerHTML = source
+  inject( source, elem ) {
+    if ( BUILD_MODE) {
+      elem.source = source
+    } else if ( USE_STYLE_TAGS ) {
+      elem.innerHTML = source
     } else {
-      let oldHref = cssElement.getAttribute( 'href' ),
+      let oldHref = elem.getAttribute( 'href' ),
         blob = new Blob( [source], { type: 'text/css' } ),
         url = URL.createObjectURL( blob )
 
-      cssElement.setAttribute( 'href', url )
+      elem.setAttribute( 'href', url )
       if ( oldHref ) URL.revokeObjectURL( oldHref )
     }
   }
 
   getElement( path, beforeElem ) {
-    console.log(`Get element ${path} ${beforeElem}`)
+    console.log(path)
+    console.log(this._cache)
     if ( !BUILD_MODE ) {
       let id = `jspm-css-loader-${path}`
       return document.getElementById( id ) || this.createElement( id, beforeElem )
+    } else {
+      let idx = this._cache.findIndex( e => e.path === path )
+      return idx >= 0 ? this._cache[idx] : this.createInCache( path, beforeElem )
     }
   }
 
@@ -80,11 +87,19 @@ class CSSLoader {
       cssElement.setAttribute( 'rel', 'stylesheet' )
     }
     cssElement.setAttribute( 'id', id )
-    console.log(beforeElem)
-    if (beforeElem) console.log(this.getElement( beforeElem ))
     head.insertBefore( cssElement, beforeElem ? this.getElement( beforeElem ) : null )
 
     return cssElement
+  }
+
+  createInCache( path, beforeElem ) {
+    let elem = { path }
+    if ( beforeElem ) {
+      this._cache.splice( this._cache.findIndex( e => e.path === beforeElem ), 0, elem )
+    } else {
+      this._cache.push( elem )
+    }
+    return elem
   }
 
   triggerImport( _newPath, relativeTo ) {
@@ -95,18 +110,21 @@ class CSSLoader {
       canonicalParent = relativeTo.replace( /^\//, '' )
     this._deps[canonicalParent].push( `${newPath}!${this.moduleName}` )
 
-    this.getElement( canonicalPath, canonicalParent )
-    console.log( `Imports: ${relativeTo} imports ${canonicalPath}` )
+    // This ensures elements are created in the right order:
+    // dependencies before parents, siblings in source-order
+    let elem = this.getElement( canonicalPath, canonicalParent )
+    console.log( `Imports: ${relativeTo} -> ${canonicalPath}` )
 
     return System.import( `./${canonicalPath}!${this.moduleName}` ).then( exportedTokens => {
       // If we're in BUILD_MODE, the tokens aren't actually returned,
       // but they have been added into our cache.
-      return BUILD_MODE ? this._cache[canonicalPath] : exportedTokens.default
+      return BUILD_MODE ? elem.tokens : exportedTokens.default
     } )
   }
 
   bundle( loads, opts ) {
-    let css = this._cache._source.join( "\n" )
+    console.log(this._cache)
+    let css = this._cache.map( c => c.source ).join( "\n" )
       .replace( /(["\\])/g, '\\$1' )
       .replace( /[\f]/g, "\\f" )
       .replace( /[\b]/g, "\\b" )


### PR DESCRIPTION
In response to #9, I had to ensure that the files are being loaded in the correct order. For the record the order is:
1. Children before parents
2. Siblings in source order

There's actually a test for this exact thing [here](https://github.com/css-modules/css-modules-loader-core/tree/master/test/test-cases/multiple-dependencies), but that uses the FileSystemLoader, so this needed to be implemented. Verified this works on both live & build modes.
