### PR TITLE
feat: use SystemJS config rules in CSS imports

### DIFF
--- a/lib/CSSModuleLoaderProcess.js
+++ b/lib/CSSModuleLoaderProcess.js
@@ -19,7 +19,7 @@ export class CSSModuleLoaderProcess {
   }
 
   fetch (load, systemFetch) {
-    const sourcePath = path.relative(System.baseURL, load.address)
+    const sourcePath = this._extractCanonicalPathFromImportPath(load.address)
 
     const styleSheet = {
       name: sourcePath,
@@ -45,14 +45,23 @@ export class CSSModuleLoaderProcess {
     // Figure out the path that System will need to find the right file,
     // and trigger the import (which will instantiate this loader once more)
     const newPath = _newPath.replace(/^["']|["']$/g, '')
-    const canonicalPath = path.resolve(path.dirname(relativeTo), newPath).replace(/^\//, '')
     const canonicalParent = relativeTo.replace(/^\//, '')
 
-    this._stylesDependencyTree.add([canonicalParent, canonicalPath])
-
     return System.normalize(newPath + '!', path.join(System.baseURL, canonicalParent))
+      .then((importPath) => {
+        const canonicalPath = this._extractCanonicalPathFromImportPath(importPath)
+        this._stylesDependencyTree.add([canonicalParent, canonicalPath])
+        return importPath
+      })
       .then(System.import.bind(System))
       .then((exportedTokens) => exportedTokens.default || exportedTokens)
+  }
+
+  _extractCanonicalPathFromImportPath (importPath) {
+    return (importPath.startsWith(System.baseURL)
+      ? path.relative(System.baseURL, importPath)
+      : importPath)
+    .replace(/!.*$/, '')
   }
 
   _styleExportModule (exportTokens) {


### PR DESCRIPTION
The loader will now normalize the given path through SystemJS.
This allows you to use SystemJS custom paths/maps in your CSS imports.

The following `composes` are now valid :

``` js
// Your config.js
System.config({
  paths: {
    "github:*": "jspm_packages/github/*",
    "~/*": "somewhere/*"
  }
}
```

``` css
// Your ike.icss
.ike {
  composes: bounce animated from "https://github.jspm.io/daneden/animate.css@v3.1.0/dist/animate.css";
  composes: bounce animated from "github:daneden/animate.css@v3.1.0/dist/animate.css";
  composes: bounce animated from "~/animate.css";
}
```
