### PR TITLE
Remove System requirement from bundled code.

### DIFF
--- a/lib/CSSModuleLoaderProcess.js
+++ b/lib/CSSModuleLoaderProcess.js
@@ -65,7 +65,7 @@ export class CSSModuleLoaderProcess {
   }
 
   _styleExportModule (exportTokens) {
-    return `export default ${JSON.stringify(exportTokens)}`
+    return `module.exports = ${JSON.stringify(exportTokens)}`
   }
 
   _getSortedStylesDependencies () {


### PR DESCRIPTION
Fetch isn't allowed to return ES6 logic if one is going to bundle w/o SystemJS' runtime. By changing the export string from 'export default' to 'module.exports' we remove a need for System in bundles.
