### PR TITLE
Add an option to produce a separate CSS file (fix #6) and minification (fix #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ For the full CSS Modules syntax, where everything is local by default, see the [
 
 The loader also supports the CSS Modules Interchange Format. 
 
+## Builder Support
+
+When building with [SystemJS Builder](https://github.com/systemjs/builder), by default CSS will be inlined into the JS bundle and injected on execution.
+
+To alter this behaviour use the SystemJS configuration options:
+
+* `separateCSS`: true / false whether to build a CSS file at the same output name as the bundle itself to be included with a link tag. Defaults to false.
+* `buildCSS`: true / false whether to bundle CSS files or leave as separate requests. Defaults to true.
+* `rootURL`: Optional, address that when set normalizes all CSS URLs to be absolute relative to this path.
+
+## Source Maps
+
+CSS source maps are supported when using the `separateCSS` output option.
+
 ## Import path notation
 
 The path you specify will be processed through SystemJS with your [configuration](https://github.com/systemjs/systemjs/blob/master/docs/config-api.md).  

--- a/lib/CSSLoaderBuilded.js
+++ b/lib/CSSLoaderBuilded.js
@@ -1,16 +1,32 @@
-//
+// it's bad to do this in general, as code is now heavily environment specific
+var fs = System._nodeRequire('fs')
 
 import {CSSModuleLoaderProcess} from './CSSModuleLoaderProcess'
 
 const CSS_INJECT_FUNCTION = "(function(c){if (typeof document == 'undefined') return; var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})"
 const EMPTY_SYSTEM_REGISTER = (system, name) => `${system}.register('${name}', [], function() { return { setters: [], execute: function() {}}});`
 
+var that
+
+function escape(source) {
+  return source
+    .replace(/(["\\])/g, '\\$1')
+    .replace(/[\f]/g, "\\f")
+    .replace(/[\b]/g, "\\b")
+    .replace(/[\n]/g, "\\n")
+    .replace(/[\t]/g, "\\t")
+    .replace(/[\r]/g, "\\r")
+    .replace(/[\']/g, "\\'")
+    .replace(/[\u2028]/g, "\\u2028")
+    .replace(/[\u2029]/g, "\\u2029")
+}
+
 export class CSSLoaderBuilded extends CSSModuleLoaderProcess {
   constructor (plugins, moduleName) {
     super(plugins, moduleName)
 
-    // enforce this on exported functions
-    this.bundle = this.bundle.bind(this)
+    // keep a reference to the class instance
+    that = this
   }
 
   fetch (load, systemFetch) {
@@ -19,17 +35,65 @@ export class CSSLoaderBuilded extends CSSModuleLoaderProcess {
       .then((styleSheet) => styleSheet.exportedTokens)
   }
 
-  bundle (loads, compileOpts) {
-    const fileDefinitions = loads
+  bundle (loads, compileOpts, outputOpts) {
+    var loader = this
+    if (loader.buildCSS === false)
+      return ''
+
+    return loader['import']('clean-css').then(function(CleanCSS) {
+
+      var rootURL = loader.rootURL
+
+      var cssOptimize = loader.separateCSS && outputOpts.minify && outputOpts.cssOptimize !== false
+
+      var outFile = loader.separateCSS ? outputOpts.outFile.replace(/\.js$/, '.css') : rootURL
+
+      var cleanCSS = new CleanCSS({
+        advanced: cssOptimize,
+        agressiveMerging: cssOptimize,
+        mediaMerging: cssOptimize,
+        restructuring: cssOptimize,
+        shorthandCompacting: cssOptimize,
+        keepBreaks: !cssOptimize,
+
+        target: outFile,
+        relativeTo: rootURL,
+        sourceMap: !!outputOpts.sourceMaps,
+        sourceMapInlineSources: outputOpts.sourceMapContents
+      }).minify(that._getAllSources())
+
+      if (cleanCSS.errors.length)
+        throw new Error('CSS Plugin:\n' + cleanCSS.errors.join('\n'))
+
+      var cssOutput = cleanCSS.styles
+
+      const fileDefinitions = loads
       .map((load) => EMPTY_SYSTEM_REGISTER(compileOpts.systemGlobal || 'System', load.name))
       .join('\n')
 
-    return `
-// Fake file definitions
-${fileDefinitions}
-// Inject all the css
-${CSS_INJECT_FUNCTION}
-('${this._getAllSources()}');`
+      // write a separate CSS file if necessary
+      if (loader.separateCSS) {
+        if (outputOpts.sourceMaps) {
+          fs.writeFileSync(outFile + '.map', cleanCSS.sourceMap.toString())
+          cssOutput += '/*# sourceMappingURL=' + outFile.split(/[\\/]/).pop() + '.map*/'
+        }
+
+        fs.writeFileSync(outFile, cssOutput)
+
+        return fileDefinitions
+      }
+
+      return `
+      // Fake file definitions
+      ${fileDefinitions}
+      // Inject all the css
+      ${CSS_INJECT_FUNCTION}
+      ('${escape(cssOutput)}');`
+    }, function(err) {
+      if (err.toString().indexOf('ENOENT') != -1)
+        throw new Error('Install Clean CSS via `jspm install npm:clean-css --dev` for CSS build support. Set System.buildCSS = false to skip CSS builds.')
+      throw err
+    });
   }
 
   _getAllSources () {
@@ -37,13 +101,5 @@ ${CSS_INJECT_FUNCTION}
     return sortedDependencies
       .map((depName) => this._styleMeta.get(depName).injectableSource)
       .join('\n')
-      .replace(/(['\\])/g, '\\$1')
-      .replace(/[\f]/g, '\\f')
-      .replace(/[\b]/g, '\\b')
-      .replace(/[\n]/g, '\\n')
-      .replace(/[\t]/g, '\\t')
-      .replace(/[\r]/g, '\\r')
-      .replace(/[\u2028]/g, '\\u2028')
-      .replace(/[\u2029]/g, '\\u2029')
   }
 }

--- a/lib/CSSLoaderBuilded.js
+++ b/lib/CSSLoaderBuilded.js
@@ -1,6 +1,3 @@
-// it's bad to do this in general, as code is now heavily environment specific
-var fs = System._nodeRequire('fs')
-
 import {CSSModuleLoaderProcess} from './CSSModuleLoaderProcess'
 
 const CSS_INJECT_FUNCTION = "(function(c){if (typeof document == 'undefined') return; var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})"
@@ -73,6 +70,8 @@ export class CSSLoaderBuilded extends CSSModuleLoaderProcess {
 
       // write a separate CSS file if necessary
       if (loader.separateCSS) {
+        // it's bad to do this in general, as code is now heavily environment specific
+        var fs = System._nodeRequire('fs')
         if (outputOpts.sourceMaps) {
           fs.writeFileSync(outFile + '.map', cleanCSS.sourceMap.toString())
           cssOutput += '/*# sourceMappingURL=' + outFile.split(/[\\/]/).pop() + '.map*/'


### PR DESCRIPTION
By default, CSS is inlined into the JS bundle and injected on execution.
This commit adds an option (`separateCSS`) that allows to produce a separate CSS
file, as available in the main CSS plugin[1].
The code is heavily influenced by the main CSS plugin, so it also uses
clean-css[2] under the hood to produce the CSS file.

One nice side effect of using clean-css is that we can also optionally minify
the CSS, using the Jspm CLI option --minify/-m

> jspm bundle ... --minify

CSS source maps are also supported thanks to clean-css.

[1] https://github.com/systemjs/plugin-css
[2] https://github.com/jakubpawlowicz/clean-css
